### PR TITLE
Postfix chain refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,11 @@ A small expression language with variables, function calls, simple types and com
   - Parentheses ( ... ) group sub-expressions.
 - Identifiers, variables and functions
   - Identifiers follow the usual rules: start with a letter or underscore, then letters, digits, or underscores.
-  - Dotted paths are supported to reference nested names: a.b.c. 
-  - An identifier may be followed by a function call with parentheses and parameters: ns.func(arg1, arg2).
+  - Postfix chaining after any primary expression:
+    - Member access: .field (dictionary/object field lookup, no method dispatch)
+    - Indexing: [expr]
+    - Calls: (arg1, arg2)
+    - These can be chained left-to-right: `a.b.c`, `a.b(1, 2).c[0].d(e)`, `foo(1)(2)(3)`, `arr[1+2][0]`.
 - Operators
   - Arithmetic: +, -, *, /, %, ^
   - Comparisons: <, <=, >, >=, ==, !=

--- a/src/types.rs
+++ b/src/types.rs
@@ -50,8 +50,9 @@ impl Atom {
 #[derive(Debug, Clone, PartialEq)]
 pub enum Expr {
     Basic(Atom),
-    Path(Vec<String>),
+    Var(String),
     Member { object: Box<Expr>, field: String },
+    Index { object: Box<Expr>, index: Box<Expr> },
     Call { callee: Box<Expr>, args: Vec<Expr> },
     Unary { op: UnaryOp, expr: Box<Expr> },
     Binary { op: BinaryOp, left: Box<Expr>, right: Box<Expr> },

--- a/tasks/1_postfix-chain-refactor.md
+++ b/tasks/1_postfix-chain-refactor.md
@@ -1,0 +1,78 @@
+# Step 1 — Postfix chain refactor (expression core)
+
+Goal: Replace the current special-cased dotted path + single-call handling with a unified, extensible postfix-chain for expressions: primary followed by any number of member access `.field`, index `[expr]`, and call `(args)` operations. This lays the foundation for lists/dicts, assignment targets, and functions while keeping the expression parser modular.
+
+Key constraints from requirements:
+- Expression parser must remain modular and usable stand-alone (there will be contexts with expressions only, no statements).
+- Future features will add lists/dicts, ternary, assignment (statement-only), and statements/blocks. Do not introduce statements in this step.
+- Dot methods are dictionary traversal, not method dispatch.
+
+Deliverables in this step:
+1) AST updates (minimally invasive, forward-compatible)
+- Expr variants:
+  - Keep: Basic(Atom), Unary, Binary.
+  - Replace Path(Vec<String>) with Var(String) for a base identifier and add Member/Index/Call in a uniform way.
+  - New/updated:
+    - Var(String)
+    - Member { object: Box<Expr>, field: String }
+    - Index { object: Box<Expr>, index: Box<Expr> }
+    - Call { callee: Box<Expr>, args: Vec<Expr> }
+- Optional helper: an accessor to recognize a simple variable name quickly.
+
+2) Parser changes (chumsky)
+- Primary:
+  - literals (existing)
+  - identifiers → Expr::Var
+  - parenthesized expression
+- Postfix loop (left-assoc): repeatedly apply one of
+  - Call: `(` args? `)`
+  - Index: `[` expr `]`
+  - Member: `.` ident
+- Precedence: postfix > unary > pow (right-assoc) > mul/div/mod > add/sub > comparisons > equality > && > ||.
+- Remove current special-cased `path`/`path_or_call`/`path_call_and_members` in favor of the generic postfix loop.
+- Shared spacer retained; comments/whitespace as before.
+
+3) Evaluator updates (temporary behavior)
+- Name lookup currently uses VariableResolver::resolve on full paths. Update to:
+  - Eval Var(name) → treat as a path with one segment for resolve([]) compatibility; or create a helper that resolves a flat name.
+  - Eval Member/Index now should not try to flatten entire path into Vec<String>. Instead, do real traversal:
+    - For this step, you may keep old functionality by supporting Member(object, field) only when `object` flattens to a Vec<String>. Keep a TODO to implement full value traversal in step 2.
+  - Eval Call should accept any Expr callee, not only Path; similarly, keep a temporary path flattening as an interim solution.
+- Keep existing Atom-only arithmetic semantics unchanged in this step.
+
+4) Public API
+- Maintain parse(input) -> Result<Expr> with the new AST shape.
+- Keep a separate entry point to obtain the expression parser (e.g., parser::parser()) suitable for embedding.
+
+5) Tests (unit or doc tests)
+- Parsing:
+  - `a.b.c` → Member(Member(Var("a"), "b"), "c")
+  - `a.b(1, 2).c[0].d(e)` → correct postfix chain shape
+  - `(a + b).c(d)` is allowed and parsed as postfix applied to parenthesized expr
+  - `foo(1)(2)(3)` chains calls
+  - `arr[1+2][0]`
+- Precedence:
+  - `a.b + c.d` parses as Binary(Add, postfix(a.b), postfix(c.d))
+  - `a.b(c) && d.e` groups correctly
+- Evaluator temp behavior:
+  - Existing path/call tests still pass; adapt resolver usage minimally. Where necessary, resolve Var or flatten member chain into a Vec<String> as before.
+
+6) Migration notes
+- Mark flatten_member_path as deprecated/TODO for removal in step 2 when full value traversal (dict/list) is implemented.
+- Update any examples in README to reflect the new more general postfix support if present.
+
+Implementation outline (parser):
+- ident = text::ident().map(String::from)
+- primary = choice(literal, ident→Var, parens(expr)) .padded_by(spacer)
+- postfix = primary.then(
+    choice(
+      args_list delimited by ( ) → |args| Postfix::Call(args),
+      expr delimited by [ ] → Postfix::Index(expr),
+      dot ident → Postfix::Member(name)
+    ).repeated()
+  ).map(|(base, posts)| apply sequentially)
+- Replace references to Path/PathOrCall in higher-precedence levels with postfix.
+
+Notes on modularity:
+- Keep expr parser constructor function exported (e.g., parser::expression_parser()) to reuse in statements later.
+- Do not introduce statements, semicolons, or assignments here to avoid churn.

--- a/tasks/2_lists_and_dicts.md
+++ b/tasks/2_lists_and_dicts.md
@@ -1,0 +1,67 @@
+# Step 2 — Lists and dicts (literals and read-only access)
+
+Goal: Introduce list and dict literals in the expression language and enable read-only indexing/member access on them. This prepares for later mutation and assignments. Keep expression parser modular.
+
+Key constraints from requirements:
+- Dict keys can only be strings (either identifiers mapped to strings later via semantics, or string literals; in this step prefer string literals to be explicit).
+- Truthiness across all types will be used later; start shaping Value accordingly.
+- Dot access is dictionary traversal; there is no method dispatch. `obj.field` means get the value for key "field" on a dict-like value. For non-dict values, this is an error (friendly error value).
+- Missing key or out-of-bounds index should return a friendly error value, not panic.
+
+Deliverables in this step:
+1) Runtime types
+- Introduce a top-level Value enum beyond Atom to represent composite runtime values:
+  - Value::Atom(Atom)
+  - Value::List(Vec<Value>)
+  - Value::Dict(std::collections::BTreeMap<String, Value>) (order not required)
+  - Value::Func(...) to be added later (stub now Optional)
+- Alternatively, if you want to keep Atom-only evaluator now, you can implement parse-only parts and stub evaluator to return Error for any composite evaluation. However, implementing Value now will reduce churn later.
+
+2) Parser additions
+- List literal: `[expr, expr, ...]` with optional trailing comma.
+- Dict literal: `{ "key": expr, "k2": expr, ... }` with optional trailing comma.
+  - Only allow string literal keys in this step.
+- Integrate list/dict literals as `primary` options so they naturally work with postfix chain: e.g., `{"a": [1,2]}["a"][0]`.
+
+3) Expr variants
+- Add Expr::ListLit(Vec<Expr>) and Expr::DictLit(Vec<(String, Expr)>)
+- Keep Member/Index/Call from step 1.
+
+4) Evaluator semantics (read-only)
+- Evaluate:
+  - ListLit → Value::List of evaluated elements
+  - DictLit → Value::Dict of evaluated values
+  - Index:
+    - If object is List and index is an Atom int within bounds, yield element; else friendly error Value (or Error type if you keep Result<Value>)
+    - If object is Dict and index is a string (Atom::Str), return value if present; else friendly error
+  - Member:
+    - If object is Dict, treat as string-key access; same as Index with a string key
+    - Otherwise, friendly error
+- For this step, Binary/Unary arithmetic may still operate only on Atom operands. If either side is non-Atom Value, return a friendly error.
+
+5) API shape
+- Consider splitting evaluation into two layers:
+  - evaluate_expr_to_value(&Expr) -> Result<Value>
+  - if original API returns Atom, keep evaluate_string using a projection for pure-Atom results and return errors for composite cases until later steps extend capabilities.
+
+6) Tests
+- Parsing:
+  - `[1, 2, 3]`
+  - `{"a": 1, "b": 2}`
+  - Nesting and postfix: `{"xs": [10, 20]}["xs"][1]`
+  - Member sugar: `{"a": 1}.a`
+- Evaluation:
+  - List indexing in-range/out-of-range → value / friendly error
+  - Dict lookup missing key → friendly error
+  - Dict member access equals string-key lookup
+
+7) Friendly error policy
+- Define a specific Error variant(s), e.g.:
+  - Error::IndexOutOfBounds(idx, len)
+  - Error::WrongIndexType(ty)
+  - Error::NotADict
+  - Error::NoSuchKey(key)
+- Ensure all such errors are reported without panics.
+
+8) Modularity note
+- Keep expression parser exportable as a function (e.g., expression_parser()) to be reused by statement parser later.

--- a/tasks/3_ternary.md
+++ b/tasks/3_ternary.md
@@ -1,0 +1,34 @@
+# Step 3 — Ternary operator
+
+Goal: Add ternary conditional operator `cond ? then_expr : else_expr` to the expression grammar and evaluator with correct precedence and short-circuiting semantics. Expressions remain modular.
+
+Key constraints from requirements:
+- Truthiness is allowed for any type (0/0.0 falsy, "false" falsy, empty containers may be decided later; at minimum keep Atom rules and later extend to Value).
+- Blocks are statement-only, so ternary is purely an expression.
+
+Deliverables:
+1) AST
+- Add `Expr::Ternary { cond: Box<Expr>, then_br: Box<Expr>, else_br: Box<Expr> }`.
+
+2) Parser
+- Precedence: Place ternary between assignment (when added later) and logical-or.
+  - With current layers, parse ternary right after the `or` level.
+- Associativity: Right-associative: `a ? b : c ? d : e` → `a ? b : (c ? d : e)`.
+- Grammar sketch with chumsky:
+  - let logic = existing `or` parser
+  - ternary = recursive(|self| logic.clone().then(just('?').ignore_then(self.clone()).then_ignore(just(':')).then(self.clone()).or_not()))
+    .map(|(c, rest)| match rest { Some((t, e)) => Expr::Ternary{cond: Box::new(c), then_br: Box::new(t), else_br: Box::new(e)}, None => c })
+
+3) Evaluator
+- Evaluate `cond` to a Value/Atom, compute truthiness, then evaluate only one branch (short-circuit):
+  - If truthy → evaluate `then_br`
+  - Else → evaluate `else_br`
+- Result type is the same evaluation type used for expressions in the current step.
+
+4) Tests
+- Parsing: `x ? y : z`, nested ternaries.
+- Short-circuit: ensure only chosen branch is evaluated (e.g., using a function call with side-effect in tests or a mock).
+- Truthiness across types: `0 ? 1 : 2` → 2; `1 ? 3 : 4` → 3; `"false" ? 9 : 8` → 8.
+
+5) Modularity
+- Ternary must plug into the expression parser builder function without introducing statements.

--- a/tasks/4_assignment_and_lvalues.md
+++ b/tasks/4_assignment_and_lvalues.md
@@ -1,0 +1,55 @@
+# Step 4 — Assignment and LValues (statement-only)
+
+Goal: Introduce assignment as statement-only, with support for variable creation on first use (no `let`) and assignment targets for variable, member, and index. Expressions remain modular. No closures or functions here yet.
+
+Key constraints from requirements:
+- No `let`: implicit variable creation on first assignment.
+- Assignment is statement-only; `x = y` does not produce a value.
+- Truthiness allowed globally (relevant later for control flow).
+- Friendly errors for invalid lvalues or type mismatches.
+
+Deliverables:
+1) AST additions
+- LValue:
+  - Var(String)
+  - Member { object: Box<Expr>, field: String }
+  - Index { object: Box<Expr>, index: Box<Expr> }
+- Stmt:
+  - Assign { target: LValue, value: Expr }
+  - ExprStmt(Expr) (to run function calls etc.)
+- Keep blocks/statements minimal; a full statement layer will be added in step 5.
+
+2) Parser
+- Build an lvalue parser that reuses expression primary/postfix parsing for the left side, then restrict shape:
+  - Accept: Var, Member(obj, field), Index(obj, idx)
+  - Reject: Call as lvalue (error)
+- Assignment statement grammar:
+  - lvalue `=` expr statement_terminator
+- Statement terminators:
+  - Either `;` or newline termination. Implement a `stmt_sep` parser that accepts one or more of: `;` or a newline in the shared spacer.
+- Provide a `statement_parser()` that can parse a list of statements as a block later, but in this step you can parse a single assignment or expression statement.
+- Maintain an `expression_parser()` export for expression-only contexts.
+
+3) Environment and evaluation
+- Introduce Environment as a stack of scopes:
+  - Vec<HashMap<String, Value>> with a global scope at index 0.
+- Name lookup:
+  - For assignment: if variable exists in any scope, update the nearest; else create in current (innermost) scope.
+  - For expression Var: read by searching innermost to outermost; friendly error if undefined.
+- LValue evaluation for write:
+  - Var: assign directly to env.
+  - Member: evaluate object to a Dict, clone-or-mutate in place (if you keep Rc/RefCell later; for now, if values are owned, you may need to keep values by reference inside env or model Env as Value graph that supports mutation). For this step, it is acceptable to mutate via interior mutability cell types on List/Dict wrappers.
+  - Index: similar; List index must be in range integer; Dict index must be string.
+- Friendly errors when assigning into non-dict/non-list via Member/Index or index out of bounds, wrong index type, etc.
+
+4) Tests
+- `x = 1` followed by using x
+- `user = {"name": "A"}` then `user.name = "B"`
+- `arr = [0, 1]; arr[1] = 42;`
+- Errors:
+  - `3 = x` invalid lvalue
+  - `arr[10] = 1` index out of bounds
+
+5) Modularity notes
+- Keep expression parser independent. Statement parser should consume expressions and lvalues using shared building blocks.
+- Assignment remains statement-only; do not allow `a = b` inside expression contexts.

--- a/tasks/5_statements_and_blocks.md
+++ b/tasks/5_statements_and_blocks.md
@@ -1,0 +1,48 @@
+# Step 5 — Statements and blocks (if/else, while)
+
+Goal: Introduce a statement layer with blocks and control flow: if/else, while, break/continue. Blocks are statement-only. Allow newline termination of statements (semicolons optional). Keep expression parser modular and reused.
+
+Key constraints from requirements:
+- Blocks are statement-only; no implicit last-expression value.
+- Conditions use truthiness (not strictly Bool).
+- Newline termination permitted; semicolons optional.
+- Friendly errors for misuse.
+
+Deliverables:
+1) AST additions
+- Stmt enum:
+  - Assign { target: LValue, value: Expr } (from step 4)
+  - ExprStmt(Expr)
+  - If { cond: Expr, then_block: Block, else_block: Option<Block> }
+  - While { cond: Expr, body: Block }
+  - Break
+  - Continue
+- Block(Vec<Stmt>) and Program(Vec<Stmt>) as containers.
+
+2) Parser
+- Reuse expression parser.
+- Whitespace/comments: retain the shared `spacer`; add a statement separator parser that recognizes `;` or newline(s).
+- Blocks: `{` stmt* `}`; optional trailing statement separator.
+- If/else syntax: `if (expr) block (else block)?`
+- While syntax: `while (expr) block`
+- Break/Continue: keywords; require statement separator or be followed by `}`.
+- File/program parser: zero or more statements.
+
+3) Evaluation/execution
+- Introduce control signals: enum Control { None, Break, Continue } and later Return.
+- While loop evaluates condition each iteration using truthiness. Handle break/continue by bubbling up a Control signal.
+- If evaluates condition via truthiness; execute only one branch.
+- Blocks execute statements sequentially; stop early on control signals.
+- Keep environment as a stack of scopes; for now, no new scope for blocks unless desired. (Since there is no `let`, you can choose single global scope initially. If preparing for functions, blocks could push a new scope.)
+
+4) Truthiness
+- Extend truthiness to composite Value types where needed (e.g., non-empty lists/dicts are truthy). At minimum, support Atom truthiness as earlier and treat lists/dicts as truthy when non-empty.
+
+5) Tests
+- If/else with truthy/falsy conditions.
+- While loop incrementing a counter; test break and continue.
+- Newline termination vs semicolon: both should parse.
+
+6) Modularity
+- Keep `expression_parser()` usable on its own.
+- Provide `program_parser()` and/or `block_parser()` for statement parsing.

--- a/tasks/6_loops_for_variants.md
+++ b/tasks/6_loops_for_variants.md
@@ -1,0 +1,51 @@
+# Step 6 — Loops: C-style for and foreach (list and dict)
+
+Goal: Add `for` loops in two forms:
+- C-style: `for (init?; cond?; post?) block` (desugar to while)
+- Foreach over list and dict:
+  - `for x in list { ... }`
+  - `for (k, v) in dict { ... }` (iterate key-value pairs)
+
+Key constraints from requirements:
+- Dict iteration yields key-value pairs; tuple/list destructuring on the left `(k, v)` is required for dicts.
+- Truthiness semantics for `cond`.
+- Newline termination permitted.
+
+Deliverables:
+1) AST
+- Extend Stmt with:
+  - ForC { init: Option<Box<Stmt>>, cond: Option<Expr>, post: Option<Box<Stmt>>, body: Block }
+  - ForInList { var: String, iterable: Expr, body: Block }
+  - ForInDict { key: String, val: String, iterable: Expr, body: Block }
+- Alternatively, a unified `ForIn { pattern: ForPattern, iterable: Expr, body: Block }` where `ForPattern` is `Var(String)` or `Pair(String,String)`.
+
+2) Parser
+- C-style:
+  - `for` `(` init_stmt_or_empty `;` cond_expr_or_empty `;` post_stmt_or_empty `)` block
+  - `init` and `post` can be Assign or ExprStmt; reuse statement parser pieces.
+- Foreach:
+  - `for` ident `in` expr block  → list iteration
+  - `for` `(` ident `,` ident `)` `in` expr block → dict iteration over pairs
+- Respect statement separators/newlines inside init/post parsing if you also allow newlines in `for (...)` parts; simplest is require them inside parentheses with explicit `;`.
+
+3) Evaluation/execution
+- ForC: Desugar to:
+  - Execute init (if any)
+  - While truthy(cond or true if missing) {
+      Execute body; if Continue → clear and continue; if Break → exit;
+      Execute post (if any)
+    }
+- ForIn list:
+  - Evaluate iterable to Value::List; iterate values by cloning or referencing; assign to `var` in current scope each iteration; execute body with break/continue semantics.
+- ForIn dict:
+  - Evaluate iterable to Value::Dict; iterate over (key, value) pairs; assign to `key` and `val` variables.
+- Friendly errors when iterable is wrong type.
+
+4) Tests
+- ForC counting loop; ensure post runs each time.
+- Foreach list sums values.
+- Foreach dict prints keys/values or accumulates.
+- Break and continue in both loop types.
+
+5) Modularity
+- Expression parser continues to be reusable; statements compose it.

--- a/tasks/7_functions.md
+++ b/tasks/7_functions.md
@@ -1,0 +1,47 @@
+# Step 7 — Functions (definitions and calls)
+
+Goal: Add user-defined functions with definitions and calls; no closures initially. Functions are first-class values and can be assigned to variables; nested functions are only via assignment of function values to variables. Implement `return` to exit early from functions.
+
+Key constraints from requirements:
+- Forbid closures initially (no capturing of outer locals). Globals/builtins are accessible.
+- Functions assignable to variables; nested functions via assignment only.
+- Assignment stays statement-only.
+
+Deliverables:
+1) AST
+- Extend Stmt with:
+  - FnDef { name: String, params: Vec<String>, body: Block }
+  - Return(Option<Expr>)
+- Extend Value with Value::Func(Function).
+- Function representation:
+  - enum Function { User { params: Vec<String>, body: Block }, Native(fn(&[Value]) -> Result<Value>) }
+
+2) Parser
+- Function definition: `fn name(params...) block`
+  - Params: `ident (',' ident)*` with optional trailing comma.
+- Calls are already part of postfix chain; they now accept any callee expression that evaluates to a function value.
+- Return statement: `return` expr? statement_terminator
+
+3) Evaluation
+- Name binding: defining a function binds a Value::Func in the current scope.
+- Calling a function:
+  - Evaluate callee to Value::Func.
+  - Evaluate args left-to-right.
+  - Create a new call scope (push a new scope frame):
+    - Bind parameters by value to arguments (arity must match; friendly error otherwise).
+  - Execute function body block until completion or Return signal.
+  - On `Return(Some expr))` produce the value of expr; `Return(None)` yields a Unit/None value (choose a Value::Unit or special Atom/Value variant).
+  - Ensure no closures: disallow references to outer local variables from inside function body. The simplest is to only allow resolving names from the call scope and global scope; do not capture current locals when creating the function value.
+
+4) Numeric behavior clean-up
+- Int/Int division → Float; ensure evaluator enforces this globally now.
+
+5) Tests
+- Simple function returning a value.
+- Recursive function like factorial.
+- Wrong arity error.
+- Function as a value assigned to a var and then called.
+- Return without expression.
+
+6) Modularity
+- Expression parser already supports calls; statements now include FnDef and Return. Expression-only contexts remain unaffected.

--- a/tasks/8_builtins_and_methods.md
+++ b/tasks/8_builtins_and_methods.md
@@ -1,0 +1,32 @@
+# Step 8 — Built-ins and dot access policy
+
+Goal: Provide a minimal set of built-in functions available in the global scope and clarify that dot `.` access is purely dict key traversal (not method dispatch). If you want to expose list/dict utilities, either export them as globals (e.g., `push(list, v)`) or place functions in dicts to make `obj.util(args)` work via traversal.
+
+Key constraints from requirements:
+- Everything accessible via `.` should be dict traversal. There is no hidden method dispatch.
+- Dict ordering does not matter.
+
+Deliverables:
+1) Built-ins
+- Provide a small stdlib in the root/global scope as a dict of functions:
+  - print(...)
+  - len(x)
+  - type(x)
+  - keys(dict), values(dict), items(dict) returning list of pairs
+- Represent as Value::Func(Native(...)) entries in the global environment.
+
+2) Dot access policy
+- Document that `obj.field` retrieves the value under key `"field"`. If that value is a function, `obj.field(args)` calls it because calls work on any callee expression.
+- If you want method-like sugar, you can organize values like: `list_methods = { "push": fn(l, x) { ... } }` and then `list_methods.push(my_list, 1)`; or attach such dict under `list` key in the environment. The runtime does not add implicit `this`.
+
+3) Parser
+- No changes; dot/member access is already supported from earlier steps.
+
+4) Evaluator
+- Implement native built-ins as host callbacks producing friendly errors on wrong types.
+
+5) Tests
+- Calling built-ins; dot traversal to reach functions stored inside dicts.
+
+6) Documentation
+- Update README with a section on built-ins and dot traversal semantics; emphasize no magic methods.

--- a/tasks/9_polish_and_errors.md
+++ b/tasks/9_polish_and_errors.md
@@ -1,0 +1,54 @@
+# Step 9 — Polish: error policy, numeric rules, docs, and tests
+
+Goal: Finalize friendly error behavior, numeric semantics, equality, and documentation; add tests to cover edge cases and ensure expression-only and statement modes remain cleanly separated.
+
+Requirements to encode:
+- Friendly errors instead of panics for:
+  - Missing dict key
+  - Index out of bounds
+  - Wrong index type
+  - Using member access on non-dict
+  - Calling non-callable
+  - Undefined variable on read
+- Int/Int division must produce Float.
+- Equality is structural across lists/dicts and type-sensitive.
+- Dict ordering does not matter.
+- Newline statement termination permitted everywhere a statement is expected.
+
+Tasks:
+1) Error enums and messages
+- Add/confirm rich Error variants with context (operation, index/key, type names).
+- Ensure all evaluation paths return Result<T, Error> and do not panic on user inputs.
+
+2) Truthiness
+- Define and centralize truthiness:
+  - Atom: Int 0/Float 0.0 → false; Bool as-is; Str "false" → false, otherwise true (per current behavior); extend if desired for empty strings.
+  - Composite: List/Dict → truthy if non-empty.
+
+3) Division and numeric coercion
+- Implement Int/Int → Float; Int/Float or Float/Int → Float.
+- Division by zero → friendly error.
+
+4) Equality and comparisons
+- Implement structural equality for lists/dicts.
+- Comparison operations only for numeric types (error otherwise); document behavior explicitly.
+
+5) Parser polish
+- Ensure trailing commas in list/dict literals.
+- Ensure newline-based statement terminators work in blocks and top-level program parsing.
+
+6) Tests
+- Error cases listed above.
+- Numeric division/coercion cases.
+- Structural equality tests for nested lists/dicts.
+- Statement termination with newline-only.
+
+7) Documentation
+- Update README with final syntax summary and examples:
+  - Literals, collections, indexing/member access
+  - Ternary
+  - Assignments (statement-only)
+  - If/while/for loops
+  - Functions and returns
+  - Built-ins and dot traversal semantics
+- Mention expression-only parser entrypoint and usage.

--- a/tasks/high_level_goals.md
+++ b/tasks/high_level_goals.md
@@ -1,0 +1,287 @@
+### Goals recap
+You want to evolve a simple expression language into a small but ergonomic scripting language with:
+- Expressions: add ternary operator, list and dict literals, indexing, assignment.
+- Statements and control flow: conditionals and loops (while, C-style for, foreach).
+- Function definitions and calls.
+- A refactor of name lookup and “object” traversal to enable dot/member access, index access, and callables to coexist cleanly.
+- A practical architecture and rollout plan with clear semantics.
+
+Below is a concrete design that scales, is implementable in small steps, and fits nicely with your existing parser approach (chumsky).
+
+---
+
+### High-level architecture
+- Lexing/parsing: keep chumsky; add a statement layer with blocks and declarations above your expression grammar.
+- AST: split into Expr, LValue, Stmt, Block, and Program. This isolates assignment targets and control flow.
+- Runtime types: a Value enum for primitives and composites, and a Function type representing user-defined and native built-ins.
+- Environments: an Environment stack (Vec of scopes) for lexical scoping and a separate Value traversal system for member/index access.
+- Interpreter: evaluate statements and expressions with short-circuiting and a small set of control signals (Break, Continue, Return).
+
+---
+
+### Core runtime model
+
+#### Value
+- Int(i64), Float(f64), Bool, Str(String)
+- List(Vec<Value>)
+- Dict(Map<String, Value>) — Map can be BTreeMap (deterministic order) or IndexMap (preserve insertion order).
+- Func(Function) — user-defined or native function.
+- Unit — for statements without a value (or use Option<Value> with None as Unit).
+
+Optional future: Null/None, ranges, iterators.
+
+#### Function
+- User { params: Vec<String>, body: Block, maybe captures } — start without closures.
+- Native(fn(&[Value]) -> Result<Value>) + metadata (name, arity, doc).
+
+#### Environment and lookup
+- Environment: Vec<Scope>, Scope = HashMap<String, Value>.
+- Name lookup: search from innermost scope outward.
+- Path/member traversal: resolve base identifier to a Value, then traverse:
+    - Member: obj.field — Dict => get field; else error (optionally add method maps later).
+    - Index: obj[idx] — List: idx is int within bounds; Dict: idx is string.
+- LValues support write targets: Var(name), Member(obj, field), Index(obj, idx).
+
+This matches your desire to look up “objects” independently and then traverse.
+
+---
+
+### Grammar and AST
+
+#### Expression precedence (low to high)
+- Assignment: target = expr (right associative). Optionally add compound ops later.
+- Ternary: cond ? then : else
+- Or: a || b
+- And: a && b
+- Equality: ==, !=
+- Comparison: <, <=, >, >=
+- Add/sub: +, -
+- Mul/div/mod: *, /, %
+- Pow: ^ (right-assoc)
+- Unary: !, - (negation)
+- Postfix chain: call, index, member (left-assoc): expr(args), expr[expr], expr.field
+- Primary: literals, identifiers, parenthesized
+
+#### New literals
+- List: [expr, expr, …] with optional trailing comma.
+- Dict: { key: expr, key2: expr, … } where key is ident or string literal to start.
+
+#### AST shapes
+- Expr
+    - Literal(Int/Float/Bool/Str)
+    - Var(String)
+    - Member { object: Box<Expr>, field: String }
+    - Index { object: Box<Expr>, index: Box<Expr> }
+    - Call { callee: Box<Expr>, args: Vec<Expr> }
+    - Unary { op: UnaryOp, expr: Box<Expr> }
+    - Binary { op: BinaryOp, left: Box<Expr>, right: Box<Expr> }
+    - Ternary { cond: Box<Expr>, then_br: Box<Expr>, else_br: Box<Expr> }
+    - ListLit(Vec<Expr>)
+    - DictLit(Vec<(DictKey, Expr)>) where DictKey = KeyIdent(String) | KeyStr(String)
+    - Assign { target: LValue, value: Box<Expr> }  // if you want assignment as an expression
+
+- LValue
+    - Var(String)
+    - Member { object: Box<Expr>, field: String }
+    - Index { object: Box<Expr>, index: Box<Expr> }
+
+- Stmt
+    - Let { name: String, init: Option<Expr> }  // recommend explicit declarations
+    - ExprStmt(Expr)
+    - If { cond: Expr, then_block: Block, else_block: Option<Block> }
+    - While { cond: Expr, body: Block }
+    - ForC { init: Option<Box<Stmt>>, cond: Option<Expr>, post: Option<Box<Stmt>>, body: Block }
+    - ForIn { var: String, iterable: Expr, body: Block }  // start with simple var pattern
+    - Break, Continue
+    - Return(Option<Expr>)
+    - FnDef { name: String, params: Vec<String>, body: Block }
+
+- Block(Vec<Stmt>)
+- Program(Vec<Stmt>)
+
+You can also keep assignment as a statement-only feature initially if you prefer.
+
+---
+
+### Parsing plan with chumsky
+
+- Spacing/comments: you already have whitespace and line comments; keep a shared spacer parser.
+- Postfix chain: switch to a primary parser and then repeatedly apply postfix operators in a loop: call(args), index([expr]), member(.ident). This subsumes your dotted path and call handling and enables chains like a.b(c)[0].d.
+- Literals: add list and dict literal parsers with proper delimiters and separators.
+- Ternary: parse after the logical-or level: expr '?' expr ':' expr. Ensure correct precedence and right associativity of assignment.
+- Assignment: define an lvalue parser (Var/Member/Index shapes). Parse “lvalue = expr” at the lowest precedence. If you want assignment only as a statement, parse it within statement parser and require a semicolon.
+- Statements and blocks:
+    - Block: { stmt* } with semicolons, allowing optional semicolon after block-like statements.
+    - If/else, While: classic forms with parentheses around condition.
+    - ForC: for (init?; cond?; post?) block — init/post can be Let or ExprStmt; you can desugar to While during evaluation.
+    - ForIn: for ident in expr block — iterate list values and dict keys (or pairs if you prefer).
+    - FnDef: fn name(params) block; initially disallow captures to avoid closures.
+    - Return/break/continue as keywords.
+
+Use spans from chumsky to improve error messages; reserve type/runtime errors for the evaluator.
+
+---
+
+### Evaluation semantics
+
+- Booleans and short-circuit: &&, ||, and ternary must short-circuit. Consider requiring Bool for conditions (simple and clear), at least initially.
+- Numeric ops: Int with Int -> Int; mixed -> Float; division returns Float (recommended). Pow handles floats.
+- Equality: structural for lists/dicts; type-sensitive.
+- Indexing:
+    - List: idx must be non-negative int within bounds; else error.
+    - Dict: key must be string; else error. Missing key -> error (or consider a safe_get built-in).
+- Assignment and scope:
+    - Recommend explicit declarations: let x = ... creates a new binding in current scope.
+    - Plain assignment updates the nearest existing binding; error if not previously declared.
+    - Member/Index assignments mutate in place.
+- Control flow:
+    - While: evaluate cond each iteration; break/continue via control signals.
+    - ForC: desugar to init; while (cond) { body; post; } or implement directly.
+    - ForIn: iterate lists (values) and dicts (keys). Optionally add entries() to iterate (key, value).
+- Functions:
+    - No closures initially: reject references to outer locals.
+    - New scope per call; positional params; arity must match.
+    - First-class functions are allowed so you can assign/call via variables or members.
+    - Return unwinds to nearest function; return outside function is an error.
+
+---
+
+### Refactoring name/object lookup
+
+Replace “lookup by full dotted path” with a two-phase approach:
+1) Resolve base identifier in env to a Value.
+2) Traverse postfix chain:
+    - Member: if Value::Dict => get field; else if method protocol available => resolve; else error.
+    - Index: list/dict access.
+    - Call: if Value::Func => invoke; else error.
+
+This enables seamless a.b(c)[0].d = x with LValue support for the left-hand side of assignments.
+
+---
+
+### Minimal built-ins and method protocol (optional but useful)
+
+- Globals: print, len, type, keys, values, items.
+- List methods: push, pop, insert, remove.
+- Dict methods: get, set, has, remove.
+- Provide method dispatch via a per-type method map that returns Func values so obj.method(args) desugars to method(obj, args) if desired.
+
+---
+
+### Testing strategy
+
+- Parsing tests (AST snapshots) and evaluation tests:
+    - Literals, arithmetic, precedence, strings with escapes.
+    - List/dict literals and nesting.
+    - Indexing and member access/assignment.
+    - Ternary.
+    - If/else and while (with counters to verify break/continue).
+    - ForC and ForIn.
+    - Function definition/call, recursion, return semantics, shadowing.
+    - Errors: undefined variable, type errors, index out of bounds, missing key, wrong arity, assigning to non-lvalue.
+
+Add fuzz-like random expression generators later.
+
+---
+
+### Incremental rollout plan (PR-sized steps)
+
+1) Postfix chain refactor
+- Introduce Expr::{Var, Member, Index, Call}; replace ad-hoc path/call parser with postfix loop.
+
+2) Lists and dicts
+- Add ListLit/DictLit, Value::List/Dict, and read-only indexing/member access.
+
+3) Ternary
+- Parse and evaluate with correct precedence and short-circuiting.
+
+4) Assignment + LValue
+- Add LValue validation and implement variable updates and list/dict mutations.
+- Add Let declarations (recommended) and choose declaration rules.
+
+5) Statement layer
+- Add Block, ExprStmt, If/Else, While, Break/Continue.
+
+6) Loops
+- Add ForC (desugar to While) and ForIn (lists → values, dicts → keys by default).
+
+7) Functions
+- FnDef and Func values; implement call semantics and Return.
+- Forbid closures initially; revisit later.
+
+8) Built-ins/methods
+- Small stdlib and opt-in method protocol for List/Dict.
+
+9) Polish
+- Better errors with spans, pretty-print AST, and performance tweaks.
+
+---
+
+### Concrete syntax examples
+
+- Literals and collections
+    - [1, 2, 3]
+    - {a: 1, "b": 2}
+- Postfix chains
+    - user.name
+    - arr[0]
+    - dict["key"]
+    - obj.method(1, 2).other[3]
+- Ternary
+    - is_prod ? 443 : 8080
+- Assignment
+    - let x = 1 + 2;
+    - x = x + 1;
+    - user.name = "Alice";
+    - arr[0] = 42;
+- If/while
+    - if (n > 0) { sum = sum + n; n = n - 1; } else { sum = 0; }
+    - while (i < len(arr)) { i = i + 1; }
+- For loops
+    - for (let i = 0; i < 10; i = i + 1) { sum = sum + i; }
+    - for k in dict { print(k); }
+    - for v in list { print(v); }
+- Functions
+    - fn fact(n) { if (n <= 1) { return 1; } return n * fact(n - 1); }
+    - let r = fact(5);
+
+---
+
+### Key defaults and trade-offs (recommended)
+
+- Declarations: require let for new bindings; assignment updates existing.
+- Conditions: require Bool strictly.
+- Dict keys: start with strings/idents only.
+- Division: Int/Int -> Float.
+- Blocks: keep statement-only for now (no implicit last-expression value).
+- Errors: out-of-bounds/missing-key is an error; provide safe helpers later.
+- Method style: start with free functions (push(list, x)); add dot-method sugar later.
+
+---
+
+### Clarifying questions
+
+1) Declarations: Do you want explicit let for new variables, or allow implicit creation on first assignment?
+   Answer: No "let", just implicit creation on first use
+2) Truthiness: Should conditions require Bool strictly, or allow truthy/falsy across types?
+   Answer: Allow any type to be truthy/falsy (i.e. 0 is falsy, "false" is falsy, [1, 2] is truthy, {a: 1} is truthy)
+3) Dict keys: Limit to strings/idents for now, or allow any expression as key?
+   Answer: Keys can only be strings
+4) Blocks: Should blocks be expression-valued (return last expression) or statement-only?
+   Answer: Blocks should be statement-only
+5) Foreach over dict: iterate keys, values, or key-value pairs? If pairs, do you want tuple/list destructuring?
+   Answer: Iterate key-value pairs (i.e. `for (k, v) in dict { ... }`)
+6) Method style: Should list/dict methods be accessible via dot (list.push(1)) from the start, or keep only free functions first?
+   Answer: Everything should be accessible via ".", because they are dict traversals
+7) Assignment as expression: Should x = y yield the assigned value (expression) or be statement-only?
+   Answer: Statement-only
+8) Numeric behavior: Int/Int division to Float, or keep integer division and add a separate op for float division?
+   Answer: Int/Int division to Float
+9) Semicolons: Always required inside blocks, or permit newline termination?
+   Answer: Permit newline termination
+10) Functions: OK to forbid closures initially? Are nested functions allowed? Are functions first-class (assignable to variables)?
+    Answer: Forbid closures initially; allow functions to be assigned to variables (and that's the only way to do nested functions)
+11) Dict ordering: Do you need insertion order preserved?
+    Answer: No, ordering does not matter
+12) Error policy: On missing dict key or out-of-bounds index, error or return a Null/Unit value?
+    Answer: Friendly error returned


### PR DESCRIPTION
Replace the current special-cased dotted path + single-call handling with a unified, extensible postfix-chain for expressions: primary followed by any number of member access `.field`, index `[expr]`, and call `(args)` operations.